### PR TITLE
hotfix: add rebar3_hex as a project_plugin

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
 
 {alias, [{test, [compile, {ct, "--verbose"}, cover]}]}.
 
-{project_plugins, [erlfmt, rebar3_ex_doc]}.
+{project_plugins, [erlfmt, rebar3_ex_doc, rebar3_hex]}.
 {erlfmt, [write]}.
 
 {ex_doc, [


### PR DESCRIPTION
This pull request adds rebar3_hex as a project plugin to help publish to hex